### PR TITLE
feat: rosemary selenium in docker enviroment and driver option in rosemary selenium command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ deployments.log
 
 # Node.js dependencies
 node_modules/
+
+# Selenium videos generated with selenium-grid
+docker/tmp/videos/

--- a/app/modules/auth/tests/test_selenium.py
+++ b/app/modules/auth/tests/test_selenium.py
@@ -37,7 +37,7 @@ def test_login_and_check_element():
 
             driver.find_element(
                 By.XPATH,
-                "//h1[contains(@class, 'h2 mb-3') and contains(., 'Latest datasets')]",
+                "//h1[contains(@class, 'h2 mb-3') and contains(., 'Top datasets')]",
             )
             print("Test passed!")
 

--- a/app/modules/auth/tests/test_selenium_ide/test_signup.py
+++ b/app/modules/auth/tests/test_selenium_ide/test_signup.py
@@ -15,7 +15,7 @@ class TestSignup:
 
     def test_signup(self):
         self.driver.get(get_host_for_selenium_testing())
-        self.driver.find_element(By.LINK_TEXT, "Sign Up").click()
+        self.driver.find_element(By.LINK_TEXT, "Sign up").click()
         self.driver.find_element(By.ID, "email").send_keys("user1@example.com")
         self.driver.find_element(By.ID, "password").send_keys("1234")
         self.driver.find_element(By.ID, "name").click()

--- a/core/environment/host.py
+++ b/core/environment/host.py
@@ -26,7 +26,7 @@ def get_host_for_testing(test_type: str) -> str:
         },
         "selenium": {
             "": "http://localhost:5000",
-            "/app/": "http://localhost",
+            "/app/": "http://web:5000",
             "/vagrant/": "http://localhost:5000",
         },
     }

--- a/core/selenium/common.py
+++ b/core/selenium/common.py
@@ -19,7 +19,7 @@ def initialize_driver():
     working_dir = os.environ.get("WORKING_DIR", None)
     selenium_hub_url = "http://selenium-hub:4444/wd/hub"
     if working_dir == "/app/":
-        if True or get_service_driver() == "chrome":
+        if get_service_driver() == "chrome":
             options = webdriver.ChromeOptions()
             driver = webdriver.Remote(
                 command_executor=selenium_hub_url,  # URL del Hub

--- a/core/selenium/common.py
+++ b/core/selenium/common.py
@@ -7,7 +7,7 @@ import os
 
 
 def get_service_driver():
-    return os.environ["SERVICE_DRIVER"]
+    return os.environ.get("SERVICE_DRIVER", "firefox")
 
 
 def set_service_driver(driver="firefox"):

--- a/core/selenium/common.py
+++ b/core/selenium/common.py
@@ -16,21 +16,43 @@ def set_service_driver(driver="firefox"):
 
 def initialize_driver():
     # Initialise the browser using WebDriver Manager
-    if get_service_driver() == "chrome":
-        options = webdriver.ChromeOptions()
-        service = ChromeService(ChromeDriverManager().install())
-        # if chromeDriverManager does not work for you, uncomment line 23 and comment line 21
-        # service = ChromeService('/usr/bin/chromedriver')
-        driver = webdriver.Chrome(service=service, options=options)
-    elif get_service_driver() == "firefox":
-        options = webdriver.FirefoxOptions()
-        # Inicializar el servicio y el driver
-        service = FirefoxService(GeckoDriverManager().install())
-        # if chromeDriverManager does not work for you, uncomment line 30 and comment line 28
-        # service = FirefoxService('/snap/bin/geckodriver')
-        driver = webdriver.Firefox(service=service, options=options)
+    working_dir = os.environ.get("WORKING_DIR", None)
+    selenium_hub_url = "http://selenium-hub:4444/wd/hub"
+    if working_dir == "/app/":
+        if True or get_service_driver() == "chrome":
+            options = webdriver.ChromeOptions()
+            driver = webdriver.Remote(
+                command_executor=selenium_hub_url,  # URL del Hub
+                options=options
+            )
+        elif get_service_driver() == "firefox":
+            # Configuración para usar el navegador Firefox a través de Selenium Grid
+            options = webdriver.FirefoxOptions()
+            driver = webdriver.Remote(
+                command_executor=selenium_hub_url,  # URL del Hub de Selenium
+                options=options
+            )
+
+        else:
+            raise Exception("Driver not supported")
+    elif working_dir == "":
+        if get_service_driver() == "chrome":
+            options = webdriver.ChromeOptions()
+            service = ChromeService(ChromeDriverManager().install())
+            # if chromeDriverManager does not work for you, uncomment line 23 and comment line 21
+            # service = ChromeService('/usr/bin/chromedriver')
+            driver = webdriver.Chrome(service=service, options=options)
+        elif get_service_driver() == "firefox":
+            options = webdriver.FirefoxOptions()
+            # Inicializar el servicio y el driver
+            service = FirefoxService(GeckoDriverManager().install())
+            # if chromeDriverManager does not work for you, uncomment line 30 and comment line 28
+            # service = FirefoxService('/snap/bin/geckodriver')
+            driver = webdriver.Firefox(service=service, options=options)
+        else:
+            raise Exception("Driver not supported")
     else:
-        raise Exception("Driver not supported")
+        raise Exception("Working dir not supported")
     return driver
 
 

--- a/core/selenium/common.py
+++ b/core/selenium/common.py
@@ -1,15 +1,36 @@
 from selenium import webdriver
-from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.chrome.service import Service as ChromeService
 from webdriver_manager.chrome import ChromeDriverManager
+from webdriver_manager.firefox import GeckoDriverManager
+from selenium.webdriver.firefox.service import Service as FirefoxService
+import os
+
+
+def get_service_driver():
+    return os.environ["SERVICE_DRIVER"]
+
+
+def set_service_driver(driver="firefox"):
+    os.environ["SERVICE_DRIVER"] = driver
 
 
 def initialize_driver():
-    # Initializes the browser options
-    options = webdriver.ChromeOptions()
-
     # Initialise the browser using WebDriver Manager
-    service = Service(ChromeDriverManager().install())
-    driver = webdriver.Chrome(service=service, options=options)
+    if get_service_driver() == "chrome":
+        options = webdriver.ChromeOptions()
+        service = ChromeService(ChromeDriverManager().install())
+        # if chromeDriverManager does not work for you, uncomment line 23 and comment line 21
+        # service = ChromeService('/usr/bin/chromedriver')
+        driver = webdriver.Chrome(service=service, options=options)
+    elif get_service_driver() == "firefox":
+        options = webdriver.FirefoxOptions()
+        # Inicializar el servicio y el driver
+        service = FirefoxService(GeckoDriverManager().install())
+        # if chromeDriverManager does not work for you, uncomment line 30 and comment line 28
+        # service = FirefoxService('/snap/bin/geckodriver')
+        driver = webdriver.Firefox(service=service, options=options)
+    else:
+        raise Exception("Driver not supported")
     return driver
 
 

--- a/docker/docker-compose-video.yml
+++ b/docker/docker-compose-video.yml
@@ -1,0 +1,29 @@
+services:
+
+  chrome_video:
+    image: selenium/video:ffmpeg-7.1-20250123
+    container_name: chrome-video
+    user: root
+    volumes:
+      - ./tmp/videos:/videos
+    environment:
+      - DISPLAY_CONTAINER_NAME=chrome
+      - FILE_NAME=chrome_video.mp4
+    networks:
+      - uvlhub_network
+
+  firefox_video:
+    image: selenium/video:ffmpeg-7.1-20250123
+    container_name: firefox-video
+    user: root
+    volumes:
+      - ./tmp/videos:/videos
+    environment:
+      - DISPLAY_CONTAINER_NAME=firefox
+      - FILE_NAME=firefox_video.mp4
+    networks:
+      - uvlhub_network
+
+networks:
+  uvlhub_network:
+    external: true

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -12,6 +12,7 @@ services:
     depends_on:
       - db
       - redis
+      - selenium-hub
     build:
       context: ../
       dockerfile: docker/images/Dockerfile.dev
@@ -71,6 +72,46 @@ services:
     networks:
       - uvlhub_network
 
+  selenium-hub:
+    image: selenium/hub:latest
+    container_name: selenium-hub
+    ports:
+      - "4442:4442"
+      - "4443:4443"
+      - "4444:4444"
+    networks:
+      - uvlhub_network
+
+  chrome:
+    image: selenium/node-chrome:latest
+    container_name: selenium-chrome
+    shm_size: 2gb
+    environment:
+      - SE_EVENT_BUS_HOST=selenium-hub
+      - SE_EVENT_BUS_PUBLISH_PORT=4442
+      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+      - VNC_NO_PASSWORD=1
+      - SE_NODE_MAX_SESSIONS=1
+    depends_on:
+      - selenium-hub
+    networks:
+      - uvlhub_network
+
+  firefox:
+    image: selenium/node-firefox:latest
+    container_name: selenium-firefox
+    shm_size: 2gb
+    environment:
+      - SE_EVENT_BUS_HOST=selenium-hub
+      - SE_EVENT_BUS_PUBLISH_PORT=4442
+      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+      - VNC_NO_PASSWORD=1
+      - SE_NODE_MAX_SESSIONS=1
+    depends_on:
+      - selenium-hub
+    networks:
+      - uvlhub_network
+
 volumes:
   db_data:
 
@@ -78,3 +119,6 @@ networks:
   uvlhub_network:
     driver: bridge
     name: uvlhub_network
+  docker_uvlhub_network:
+    driver: bridge
+    name: docker_uvlhub_network

--- a/docker/images/Dockerfile.dev
+++ b/docker/images/Dockerfile.dev
@@ -20,6 +20,11 @@ RUN apt-get install -y --no-install-recommends ca-certificates gnupg lsb-release
     && apt-get update \
     && apt-get install -y --no-install-recommends docker-ce-cli 
 
+RUN mkdir -p ~/.docker/cli-plugins/ \
+    && LATEST_VERSION=$(curl -s https://api.github.com/repos/docker/compose/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/') \
+    && curl -SL "https://github.com/docker/compose/releases/download/${LATEST_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o ~/.docker/cli-plugins/docker-compose \
+    && chmod +x ~/.docker/cli-plugins/docker-compose
+
 # Install Node.js and NPM
 RUN curl -fsSL https://deb.nodesource.com/setup_23.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
@@ -52,6 +57,7 @@ COPY rosemary/ ./rosemary
 COPY setup.py ./
 COPY docker/ ./docker
 COPY .moduleignore ./
+RUN mkdir -p /tmp  && chmod -R 777 /tmp && mkdir -p /tmp/videos && chmod -R 777 /tmp/videos
 
 # Update pip
 RUN pip install --no-cache-dir --upgrade pip

--- a/rosemary/commands/selenium.py
+++ b/rosemary/commands/selenium.py
@@ -9,7 +9,7 @@ import docker
 @click.command("selenium", help="Executes Selenium tests based on the environment.")
 @click.argument("module", required=False)
 @click.option("--driver", default="firefox", type=click.Choice(["firefox", "chrome"], case_sensitive=False), help="Specify the Selenium WebDriver to use.")
-@click.option("--video", default="false", type=click.Choice(["true", "false"], case_sensitive=False), help="Specify if you would like to record the tests.")
+@click.option("--video", default="false", type=click.Choice(["true", "false"], case_sensitive=False), help="Specify if you would like to record the tests. Only available in docker enviroment")
 def selenium(module, driver, video):
     try:
         # Absolute paths

--- a/rosemary/commands/selenium.py
+++ b/rosemary/commands/selenium.py
@@ -1,73 +1,79 @@
 import os
 import subprocess
 import click
+import core.selenium.common as driver_selector
 
 
 @click.command("selenium", help="Executes Selenium tests based on the environment.")
 @click.argument("module", required=False)
-def selenium(module):
-    # Absolute paths
-    working_dir = os.getenv("WORKING_DIR", "")
-    modules_dir = os.path.join(working_dir, "app/modules")
+@click.option("--driver", default="firefox", type=click.Choice(["firefox", "chrome"], case_sensitive=False), help="Specify the Selenium WebDriver to use.")
+def selenium(module, driver):
+    try:
+        # Absolute paths
+        working_dir = os.getenv("WORKING_DIR", "")
+        modules_dir = os.path.join(working_dir, "app/modules")
+        driver_selector.set_service_driver(driver)
+        
+        def validate_module(module):
+            """Check if the module exists."""
+            if module:
+                module_path = os.path.join(modules_dir, module)
+                if not os.path.exists(module_path):
+                    raise click.UsageError(f"Module '{module}' does not exist.")
+                selenium_test_path = os.path.join(module_path, "tests", "test_selenium.py")
+                if not os.path.exists(selenium_test_path):
+                    raise click.UsageError(
+                        f"Selenium test for module '{module}' does not exist at path "
+                        f"'{selenium_test_path}'."
+                    )
 
-    def validate_module(module):
-        """Check if the module exists."""
-        if module:
-            module_path = os.path.join(modules_dir, module)
-            if not os.path.exists(module_path):
-                raise click.UsageError(f"Module '{module}' does not exist.")
-            selenium_test_path = os.path.join(module_path, "tests", "test_selenium.py")
-            if not os.path.exists(selenium_test_path):
-                raise click.UsageError(
-                    f"Selenium test for module '{module}' does not exist at path "
-                    f"'{selenium_test_path}'."
+        def run_selenium_tests_in_local(module):
+            """Run the Selenium tests."""
+            if module:
+                selenium_test_path = os.path.join(
+                    modules_dir, module, "tests", "test_selenium.py"
                 )
+                test_command = ["python", selenium_test_path]
+            else:
+                selenium_test_paths = []
+                for module in os.listdir(modules_dir):
+                    tests_dir = os.path.join(modules_dir, module, "tests")
+                    selenium_test_path = os.path.join(tests_dir, "test_selenium.py")
+                    if os.path.exists(selenium_test_path):
+                        selenium_test_paths.append(selenium_test_path)
+                test_command = ["python"] + selenium_test_paths
 
-    def run_selenium_tests_in_local(module):
-        """Run the Selenium tests."""
+            click.echo(f"Running Selenium tests with command: {' '.join(test_command)}")
+            subprocess.run(test_command, check=True)
+
+        # Validate module if provided
         if module:
-            selenium_test_path = os.path.join(
-                modules_dir, module, "tests", "test_selenium.py"
+            validate_module(module)
+
+        if working_dir == "/app/":
+
+            click.echo(
+                click.style(
+                    "Currently it is not possible to run this "
+                    "command from a Docker environment, do you want to implement it yourself? ^^",
+                    fg="red",
+                )
             )
-            test_command = ["python", selenium_test_path]
+
+        elif working_dir == "":
+            run_selenium_tests_in_local(module)
+
+        elif working_dir == "/vagrant/":
+
+            click.echo(
+                click.style(
+                    "Currently it is not possible to run this "
+                    "command from a Vagrant environment, do you want to implement it yourself? ^^",
+                    fg="red",
+                )
+            )
+
         else:
-            selenium_test_paths = []
-            for module in os.listdir(modules_dir):
-                tests_dir = os.path.join(modules_dir, module, "tests")
-                selenium_test_path = os.path.join(tests_dir, "test_selenium.py")
-                if os.path.exists(selenium_test_path):
-                    selenium_test_paths.append(selenium_test_path)
-            test_command = ["python"] + selenium_test_paths
-
-        click.echo(f"Running Selenium tests with command: {' '.join(test_command)}")
-        subprocess.run(test_command, check=True)
-
-    # Validate module if provided
-    if module:
-        validate_module(module)
-
-    if working_dir == "/app/":
-
-        click.echo(
-            click.style(
-                "Currently it is not possible to run this "
-                "command from a Docker environment, do you want to implement it yourself? ^^",
-                fg="red",
-            )
-        )
-
-    elif working_dir == "":
-        run_selenium_tests_in_local(module)
-
-    elif working_dir == "/vagrant/":
-
-        click.echo(
-            click.style(
-                "Currently it is not possible to run this "
-                "command from a Vagrant environment, do you want to implement it yourself? ^^",
-                fg="red",
-            )
-        )
-
-    else:
-        click.echo(click.style(f"Unrecognized WORKING_DIR: {working_dir}", fg="red"))
+            click.echo(click.style(f"Unrecognized WORKING_DIR: {working_dir}", fg="red"))
+    finally:
+        driver_selector.set_service_driver("firefox")

--- a/rosemary/commands/selenium.py
+++ b/rosemary/commands/selenium.py
@@ -138,9 +138,9 @@ def selenium(module, driver, video):
                 click.style("All test have been executed. Please check /docker/tmp/videos for watching full test executions",
                             fg="green")
             )
-            click.echo("If videos don't appear try running '/scripts/clean_docker.sh'. \
+            click.echo(click.style("If videos don't appear try running '/scripts/clean_docker.sh'. \
             Then, run your docker-compose.dev and before running rosemary selenium don't forget to \
-            run this command: 'docker compose -f docker/docker-compose-video.yml up -d'", fg="blue")
+            run this command: 'docker compose -f docker/docker-compose-video.yml up -d'", fg="blue"))
 
         def run_vagrant_selenium_tests(module):
             """Run the Selenium tests in a Vagrant environment."""

--- a/rosemary/commands/selenium.py
+++ b/rosemary/commands/selenium.py
@@ -135,7 +135,7 @@ def selenium(module, driver, video):
             # we remove firefox and chrome video containers in order to access videos
             subprocess.run(f"docker compose -f {docker_compose_file} down", check=True, shell=True)
             click.echo(
-                click.style("All test have been executed. Please check /docker/tmp/videos for watching full test executions",
+                click.style("All test have been executed. Check /docker/tmp/videos for watching full test results",
                             fg="green")
             )
             click.echo(click.style("If videos don't appear try running '/scripts/clean_docker.sh'. \


### PR DESCRIPTION
This PR contains a complete solution that uses selenium-grid for running selenium tests in docker. 

1. Selenium-grid generates a container net controlled by selenium-hub. Selenium-hub container redirects all tests and manages tests queues so that all tests can be runned in nodes. There are 2 nodes, chrome and firefox. Each node has only the standalone version of its browser name. 

2. When using rosemary selenium you can also specify the browser you want to test (chrome or firefox, being the last one the default). This option is also available in local enviroment.

3. 2 selenium tests were fixed and adapted to current uvlhub version.

4. rosemary selenium now has an option called video. When video it's true, selenium tests are recorded and saved in /docker/tmp/videos. This option is only available for docker enviroment.
